### PR TITLE
ABI stabilization

### DIFF
--- a/MIA.cpp
+++ b/MIA.cpp
@@ -86,17 +86,19 @@ try
 			const auto miaModule = mia::GeneratorModule::loadFromLibrary(*dynamicLibs[x]);
 			
 			if (!miaModule)
-				continue;
+				return 1;
 			
 			app.registerModule(miaModule);
 		}
 		catch (const mia::VersionError& e)
 		{
 			spdlog::error("Version mismatch for module {0}, {1}", modules[x], e.what());
+			return 1;
 		}
 		catch (const mia::LoadError& e)
 		{
 			spdlog::error(e.what());
+			return 1;
 		}
 	}
 
@@ -112,6 +114,6 @@ try
 }
 catch (std::exception e)
 {
-	spdlog::error("Unexpected error");
+	spdlog::error("Unexpected error: {0}", e.what());
 	return 1;
 }

--- a/MIA.cpp
+++ b/MIA.cpp
@@ -53,6 +53,7 @@ try
 	}
 
 	std::vector<std::unique_ptr<mia::DynamicLibrary>> dynamicLibs;
+
 	dynamicLibs.reserve(modules.size());
  	for (const auto& x : modules)
 	{
@@ -80,12 +81,16 @@ try
 		std::make_shared<mia::modules::SerializationModule>()
 		});
 
-	for (const auto& x : dynamicLibs)
+	for (std::size_t x = 0; x < dynamicLibs.size(); ++x)
 	{
-		const auto miaModule = mia::GeneratorModule::loadFromLibrary(*x);
+		const auto miaModule = mia::GeneratorModule::loadFromLibrary(*dynamicLibs[x]);
 		if (miaModule)
 		{
 			app.registerModule(miaModule);
+		}
+		else
+		{
+			spdlog::error("Version mismatch for module {}, current MIA version is {}", modules[x], MIA_VERSION);
 		}
 	}
 

--- a/MIA.cpp
+++ b/MIA.cpp
@@ -90,7 +90,15 @@ try
 		}
 		else
 		{
-			spdlog::error("Version mismatch for module {}, current MIA version is {}", modules[x], MIA_VERSION);
+			const auto getVer = reinterpret_cast<mia::GeneratorModule::GetVersionFunc>(dynamicLibs[x]->getFuncAddress("mia_getVersion"));
+			if (getVer)
+			{
+				spdlog::error("Version mismatch for module {}, current MIA version is {}, module version is {}", modules[x], MIA_VERSION, getVer());
+			}
+			else
+			{
+				spdlog::error("Version mismatch for module {}, current MIA version is {}, unable to get module version (corrupted module?)", modules[x], MIA_VERSION);
+			}
 		}
 	}
 

--- a/include/Generator.hpp
+++ b/include/Generator.hpp
@@ -43,6 +43,21 @@ namespace mia
 		void log() const;
 	};
 
+	class CORE_EXPORT VersionError: public std::runtime_error
+	{
+	public:
+		VersionError(const char* version) : std::runtime_error(
+			fmt::format("MIA version is {0}, module version is ", MIA_VERSION) +
+			(version == nullptr ? "null(module may be corrupted)" : fmt::format("module version is {0}", version)))
+		{ }
+	};
+
+	class CORE_EXPORT LoadError : public std::runtime_error
+	{
+	public:
+		using std::runtime_error::runtime_error;
+	};
+
 	class CORE_EXPORT GeneratorModule
 	{
 	public:

--- a/include/Generator.hpp
+++ b/include/Generator.hpp
@@ -14,9 +14,11 @@
 #include <Standard.hpp>
 
 #ifdef WIN32
-#define MiaExportModule(name) extern "C" inline __declspec(dllexport) mia::GeneratorModule* mia_exportModule(const char* ver) { static name instance; return std::string_view(ver) == std::string_view(MIA_VERSION) ? &instance : nullptr; }
+#define MiaExportModule(name) extern "C" inline __declspec(dllexport) mia::GeneratorModule* mia_exportModule(const char* ver) { static name instance; return std::string_view(ver) == std::string_view(MIA_VERSION) ? &instance : nullptr; } \
+extern "C" inline __declspec(dllexport) const char* mia_getVersion() { return MIA_VERSION; }
 #else
 #define MiaExportModule(name) extern "C" inline mia::GeneratorModule* mia_exportModule() { static name instance; return std::string_view(ver) == std::string_view(MIA_VERSION) ? &instance : nullptr; }
+extern "C" inline const char* mia_getVersion() { return MIA_VERSION; }
 #endif
 
 namespace argumentum
@@ -46,6 +48,7 @@ namespace mia
 	public:
 		using Ptr = std::shared_ptr<GeneratorModule>;
 		using CreateFunc = GeneratorModule*(*)(const char*);
+		using GetVersionFunc = const char*(*)();
 
 		virtual ~GeneratorModule() = default;
 

--- a/include/Generator.hpp
+++ b/include/Generator.hpp
@@ -14,9 +14,9 @@
 #include <Standard.hpp>
 
 #ifdef WIN32
-#define MiaExportModule(name) extern "C" inline __declspec(dllexport) mia::GeneratorModule* mia_exportModule() { static name instance; return &instance; }
+#define MiaExportModule(name) extern "C" inline __declspec(dllexport) mia::GeneratorModule* mia_exportModule(const char* ver) { static name instance; return std::string_view(ver) == std::string_view(MIA_VERSION) ? &instance : nullptr; }
 #else
-#define MiaExportModule(name) extern "C" inline mia::GeneratorModule* mia_exportModule() { static name instance; return &instance; }
+#define MiaExportModule(name) extern "C" inline mia::GeneratorModule* mia_exportModule() { static name instance; return std::string_view(ver) == std::string_view(MIA_VERSION) ? &instance : nullptr; }
 #endif
 
 namespace argumentum
@@ -45,29 +45,13 @@ namespace mia
 	{
 	public:
 		using Ptr = std::shared_ptr<GeneratorModule>;
-		using CreateFunc = GeneratorModule*(*)();
+		using CreateFunc = GeneratorModule*(*)(const char*);
 
 		virtual ~GeneratorModule() = default;
 
 		virtual void extractInfo(std::ostream& outputStream, cppast::cpp_file& source) = 0;
-		[[nodiscard]]
-		virtual const char* getVersion() const = 0;
 
 		static GeneratorModule* loadFromLibrary(const DynamicLibrary& lib);
-	};
-
-	class GeneratorModuleBase
-		: public GeneratorModule
-	{
-	public:
-		GeneratorModuleBase() = default;
-		~GeneratorModuleBase() override = default;
-
-		[[nodiscard]]
-		const char* getVersion() const override
-		{
-			return MIA_VERSION;
-		}
 	};
 
 	class CORE_EXPORT Generator

--- a/include/Generator.hpp
+++ b/include/Generator.hpp
@@ -46,10 +46,7 @@ namespace mia
 	class CORE_EXPORT VersionError: public std::runtime_error
 	{
 	public:
-		VersionError(const char* version) : std::runtime_error(
-			fmt::format("MIA version is {0}, module version is ", MIA_VERSION) +
-			(version == nullptr ? "null(module may be corrupted)" : fmt::format("module version is {0}", version)))
-		{ }
+		VersionError(const char* version);
 	};
 
 	class CORE_EXPORT LoadError : public std::runtime_error

--- a/include/modules/EnumConversions.hpp
+++ b/include/modules/EnumConversions.hpp
@@ -11,7 +11,6 @@ namespace mia::modules
 	{
 	public:
 		virtual void extractInfo(std::ostream& outputStream, cppast::cpp_file& source) override;
-		virtual const char* getVersion() const override;
 	};
 }
 

--- a/include/modules/Serialization.hpp
+++ b/include/modules/Serialization.hpp
@@ -11,7 +11,6 @@ namespace mia::modules
 	{
 	public:
 		virtual void extractInfo(std::ostream& outputStream, cppast::cpp_file& source) override;
-		virtual const char* getVersion() const override;
 	};
 }
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -136,6 +136,11 @@ namespace mia
 		return it->second;
 	}
 
+	VersionError::VersionError(const char* version): std::runtime_error(
+		fmt::format("MIA version is {0}, module version is ", MIA_VERSION) +
+		(version == nullptr ? "null(module may be corrupted)" : fmt::format("module version is {0}", version)))
+	{ }
+
 	GeneratorModule* GeneratorModule::loadFromLibrary(const DynamicLibrary& lib)
 	{
 		const auto getVer = reinterpret_cast<GetVersionFunc>(lib.getFuncAddress("mia_getVersion"));

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -152,12 +152,12 @@ namespace mia
 
 		const auto funcAddr = reinterpret_cast<CreateFunc>(lib.getFuncAddress("mia_exportModule"));
 		
-		if (funcAddr)
+		if (!funcAddr)
 			throw LoadError(fmt::format("Unable to find export function in module {}", lib.getName()));
 
-		const auto res = funcAddr(MIA_VERSION);
+		auto res = funcAddr(MIA_VERSION);
 
-		if (res == nullptr)
+		if (!res)
 			throw LoadError(fmt::format("Module {} is empty", lib.getName()));
 
 		return funcAddr(MIA_VERSION);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -147,7 +147,7 @@ namespace mia
 
 		const char* ver = getVer ? getVer() : nullptr;
 
-		if (!ver || std::string(MIA_VERSION) != ver)
+		if (!ver || std::string_view(MIA_VERSION) != ver)
 			throw VersionError(ver);
 
 		const auto funcAddr = reinterpret_cast<CreateFunc>(lib.getFuncAddress("mia_exportModule"));

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -72,13 +72,9 @@ namespace mia
 	
 	void Generator::registerModule(GeneratorModule* module)
 	{
-		if (std::string_view(module->getVersion()) == MIA_VERSION)
+		if (module)
 		{
 			modules.emplace_back(module);
-		}
-		else
-		{
-			spdlog::error("Mismatching versions for module {}, module version is {}, but mia version is {}", "PLACEHOLDER_UNIMPLEMENTED", module->getVersion(), MIA_VERSION);
 		}
 	}
 
@@ -145,7 +141,7 @@ namespace mia
 		const auto funcAddr = reinterpret_cast<CreateFunc>(lib.getFuncAddress("mia_exportModule"));
 		if (funcAddr)
 		{
-			return funcAddr();
+			return funcAddr(MIA_VERSION);
 		}
 		spdlog::error("Unable to find export function in module {}", lib.getName());
 		return nullptr;

--- a/src/modules/EnumConversions.cpp
+++ b/src/modules/EnumConversions.cpp
@@ -94,9 +94,4 @@ namespace mia::modules
 				return true;
 			});
 	}
-
-	const char* EnumConversionsModule::getVersion() const
-	{
-		return MIA_VERSION;
-	}
 }

--- a/src/modules/Serialization.cpp
+++ b/src/modules/Serialization.cpp
@@ -204,9 +204,4 @@ namespace mia::modules
 			generateCodeForClass(output, x);
 		}
 	}
-
-	const char* mia::modules::SerializationModule::getVersion() const
-	{
-		return MIA_VERSION;
-	}
 }

--- a/tests/dynamic_module/MiaTestModule.cpp
+++ b/tests/dynamic_module/MiaTestModule.cpp
@@ -3,7 +3,7 @@
 #include <cppast/visitor.hpp>
 
 class TestModule
-	: public mia::GeneratorModuleBase
+	: public mia::GeneratorModule
 {
 	void extractInfo(std::ostream& outputStream, cppast::cpp_file& source) override
 	{


### PR DESCRIPTION
Changes the way module versions are pulled from the module. Allows us to change GeneratorModule interface later in the development cycle.